### PR TITLE
Fade mesh

### DIFF
--- a/examples/ensemble_transform/demo_ensemble_transform_quasi_geostrophic_single_level.py
+++ b/examples/ensemble_transform/demo_ensemble_transform_quasi_geostrophic_single_level.py
@@ -15,13 +15,12 @@ import matplotlib.pyplot as plot
 import numpy as np
 
 
-# create the mesh hierarchy (needed for coarsening localisation)
-mesh = RectangleMesh(30, 6, 5, 1)
-mesh_hierarchy = MeshHierarchy(mesh, 3)
+# design the fade type of mesh
+mesh = FadeMesh("RectangleMesh", 240, 48, 5, 1)
 
 # define function spaces
-dg_fs = FunctionSpace(mesh_hierarchy[3], 'DG', 1)
-cg_fs = FunctionSpace(mesh_hierarchy[3], 'CG', 1)
+dg_fs = FunctionSpace(mesh, 'DG', 1)
+cg_fs = FunctionSpace(mesh, 'CG', 1)
 
 
 # define initial condition ufl expression

--- a/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_algorithm_runtime.py
+++ b/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_algorithm_runtime.py
@@ -14,13 +14,10 @@ import matplotlib.pyplot as plot
 import time
 
 
-# create the mesh hierarchy (needed for coarsening localisation)
-mesh = UnitIntervalMesh(5)
-mesh_hierarchy = MeshHierarchy(mesh, 1)
+# design the fade type of mesh
+mesh = FadeMesh("UnitIntervalMesh", 10)
 
-# set used mesh to the bottom mesh
-mesh = mesh_hierarchy[-1]
-
+# generate function space
 V = FunctionSpace(mesh, 'DG', 0)
 fs = FunctionSpace(mesh, 'DG', 0)
 

--- a/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_convergence.py
+++ b/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_convergence.py
@@ -11,13 +11,10 @@ import numpy as np
 import matplotlib.pyplot as plot
 
 
-# create the mesh hierarchy (needed for coarsening localisation)
-mesh = UnitIntervalMesh(1)
-mesh_hierarchy = MeshHierarchy(mesh, 1)
+# design the fade type of mesh
+mesh = FadeMesh("UnitIntervalMesh", 1)
 
-# set used mesh to the bottom mesh
-mesh = mesh_hierarchy[0]
-
+# generate function space
 V = FunctionSpace(mesh, 'DG', 0)
 
 # the coordinates of observation (only cell)

--- a/fade/__init__.py
+++ b/fade/__init__.py
@@ -7,6 +7,7 @@ from firedrake import *  # noqa
 from fade.utils import *  # noqa
 from fade.observations import *  # noqa
 from fade.localisation import *  # noqa
+from fade.fade_mesh import *  # noqa
 
 # import ensemble transform modules
 from fade.ensemble_transform.weight_update import *  # noqa

--- a/fade/fade_mesh.py
+++ b/fade/fade_mesh.py
@@ -13,9 +13,9 @@ def FadeMesh(mesh_type, *args):
         under the returned finest mesh, up until the coarsest available mesh.
 
         Example:
-            FadeMesh(UnitSquareMesh, 16, 16) returns
-            mesh = UnitSquareMesh(16, 16) which is part of a hierarchy where the coarsest mesh
-            corresponds to a `UnitSquareMesh` with 2 cells in each geometric dimension.
+            FadeMesh("UnitIntervalMesh", 16) returns
+            mesh = UnitIntervalMesh(16) which is part of a hierarchy, size 5, where the coarsest mesh
+            corresponds to a `UnitIntervalMesh` with 1 cell.
 
         :arg mesh_type: The string of the type of :class:`Mesh` Function one requires
         :type mesh_type: str

--- a/fade/fade_mesh.py
+++ b/fade/fade_mesh.py
@@ -1,0 +1,96 @@
+""" meshes for FADE """
+
+from __future__ import division
+
+from __future__ import absolute_import
+
+from firedrake import *
+
+
+def FadeMesh(mesh_type, *args):
+
+    """ Creates a :class:`Mesh` of type `mesh_type` for the FADE package. This creates a hierarchy
+        under the returned finest mesh, up until the coarsest available mesh.
+
+        Example:
+            FadeMesh(UnitSquareMesh, 16, 16) returns
+            mesh = UnitSquareMesh(16, 16) which is part of a hierarchy where the coarsest mesh
+            corresponds to a `UnitSquareMesh` with 2 cells in each geometric dimension.
+
+        :arg mesh_type: The string of the type of :class:`Mesh` Function one requires
+        :type mesh_type: str
+
+        :arg *args: Arguments for evaluating `mesh_type`
+        :type *args: tuple
+
+    """
+
+    if isinstance(mesh_type, str) is False:
+        raise ValueError("`mesh_type` must be a string")
+
+    try:
+        eval(mesh_type)
+    except NameError:
+        raise ValueError("`mesh_type` must be a type of Mesh function")
+
+    try:
+        mesh = eval(mesh_type)(*args)
+    except TypeError:
+        raise TypeError("Mesh of `mesh_type` does not have arguments *args")
+
+    # recover the dimension of mesh
+    d = mesh.geometric_dimension()
+
+    # recover the number of cells of mesh
+    if d == 1:
+        nx = args[0]
+    elif d == 2:
+        nx = args[0]
+        ny = args[1]
+    else:
+        raise TypeError("Mesh of `mesh_type` cannot be any more than 2-dimensional")
+
+    # coarsen number of cells until not whole numbers
+    l = 0
+    converge = 0
+    while converge == 0:
+
+        if d == 1:
+
+            nnx = nx / 2.0
+
+            if (nnx % 1 == 0) and (nnx != 0):
+                l += 1
+                nx = nnx
+            else:
+                converge = 1
+
+        if d == 2:
+
+            nnx = nx / 2.0
+            nny = ny / 2.0
+
+            if (nnx % 1 == 0) and (nny % 1 == 0) and (nnx != 0) and (nny != 0):
+                l += 1
+                nx = nnx
+                ny = nny
+            else:
+                converge = 1
+
+    # define coarsest mesh
+    new_args = []
+    for i in range(len(args)):
+        new_args.append(args[i])
+    if d == 1:
+        new_args[0] = nx
+    if d == 2:
+        new_args[0] = nx
+        new_args[1] = ny
+    new_args = tuple(new_args)
+    coarsest_mesh = eval(mesh_type)(*new_args)
+
+    # create mesh hierarchy
+    mesh_hierarchy = MeshHierarchy(coarsest_mesh, l)
+
+    # return finest mesh
+    return mesh_hierarchy[-1]

--- a/fade/localisation.py
+++ b/fade/localisation.py
@@ -34,7 +34,9 @@ def CoarseningLocalisation(f, r_loc):
 
     # check r_loc is within hierarchy
     if r_loc < 0 or (lvl - r_loc) < 0:
-        raise ValueError('radius of localisation needs to be from 0 to max level of hierarchy')
+        raise ValueError('Radius of localisation needs to be from 0 to max level of hierarchy. ' +
+                         'Try using an original mesh that can be recursively coarsened in all ' +
+                         'dimensions by factor of 2')
 
     # inject down
     fc = Function(FunctionSpace(hierarchy[lvl - r_loc], fs.ufl_element()))

--- a/tests/test_fade_mesh.py
+++ b/tests/test_fade_mesh.py
@@ -61,6 +61,27 @@ def test_16_cell_2d():
     assert mesh == h[-1]
 
 
+def test_rectangle_1():
+
+    mesh = FadeMesh("RectangleMesh", 30, 5, 1, 1)
+
+    h, l = get_level(mesh)
+
+    assert mesh.num_cells() == 300
+    assert len(h) == 1
+
+
+def test_rectangle_2():
+
+    mesh = FadeMesh("RectangleMesh", 30, 6, 1, 1)
+
+    h, l = get_level(mesh)
+
+    assert mesh.num_cells() == 360
+    assert len(h) == 2
+    assert h[0].num_cells() == 90
+
+
 if __name__ == "__main__":
     import os
     pytest.main(os.path.abspath(__file__))

--- a/tests/test_fade_mesh.py
+++ b/tests/test_fade_mesh.py
@@ -1,0 +1,66 @@
+from __future__ import division
+
+from __future__ import absolute_import
+
+from firedrake import *
+
+from firedrake.mg.utils import get_level
+
+from fade import *
+
+import pytest
+
+
+def test_1_cell_1d():
+
+    mesh = FadeMesh("IntervalMesh", 1, 1)
+
+    h, l = get_level(mesh)
+
+    assert len(h) == 1
+    assert l == 0
+    assert mesh.num_cells() == 1
+    assert mesh == h[-1]
+
+
+def test_1_cell_2d():
+
+    mesh = FadeMesh("SquareMesh", 1, 1, 1)
+
+    h, l = get_level(mesh)
+
+    assert len(h) == 1
+    assert l == 0
+    assert mesh.num_cells() == 2
+    assert mesh == h[-1]
+
+
+def test_16_cell_1d():
+
+    mesh = FadeMesh("IntervalMesh", 16, 1)
+
+    h, l = get_level(mesh)
+
+    assert len(h) == 5
+    assert l == 4
+    assert mesh.num_cells() == 16
+    assert h[0].num_cells() == 1
+    assert mesh == h[-1]
+
+
+def test_16_cell_2d():
+
+    mesh = FadeMesh("SquareMesh", 16, 16, 1)
+
+    h, l = get_level(mesh)
+
+    assert len(h) == 5
+    assert l == 4
+    assert mesh.num_cells() == 512
+    assert h[0].num_cells() == 2
+    assert mesh == h[-1]
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tutorials/tutorial_ensemble_transform.py
+++ b/tutorials/tutorial_ensemble_transform.py
@@ -24,19 +24,17 @@ from fade import *
 import numpy as np
 
 
-# First of all we require a mesh, that has to be part of a hierarchy
-# of meshes to allow for the localisation that is used in FADE.
+# First of all we require a mesh. To be used within the FADE framework
+# the call for the mesh is slightly different to the one in Firedrake.
+# For localisation that is used within FADE, it is also ideal to have
+# the number of cells in each dimension to be able to be coarsened multiple
+# times by a factor of 2.
 
-mesh = UnitSquareMesh(2, 2)
-L = 1
-mesh_hierarchy = MeshHierarchy(mesh, L)
+mesh = FadeMesh("UnitSquareMesh", 2, 2)
 
-# This creates a mesh hierarchy of length `L`.
-#
-# Now let's build a function space on the finest level of the mesh
-# hierarchy.
+# Now let's build a function space on the mesh.
 
-V = FunctionSpace(mesh_hierarchy[-1], 'DG', 0)
+V = FunctionSpace(mesh, 'DG', 0)
 
 # We are ready to build an ensemble of functions on that space, of size
 # `n`. Ensembles of functions can be written as lists or tuples for FADE.

--- a/tutorials/tutorial_weight_update.py
+++ b/tutorials/tutorial_weight_update.py
@@ -14,19 +14,17 @@ from fade import *
 import numpy as np
 
 
-# First of all we require a mesh, that has to be part of a hierarchy
-# of meshes to allow for the localisation that is used in FADE.
+# First of all we require a mesh. To be used within the FADE framework
+# the call for the mesh is slightly different to the one in Firedrake.
+# For localisation that is used within FADE, it is also ideal to have
+# the number of cells in each dimension to be able to be coarsened multiple
+# times by a factor of 2.
 
-mesh = UnitSquareMesh(2, 2)
-L = 1
-mesh_hierarchy = MeshHierarchy(mesh, L)
+mesh = FadeMesh("UnitSquareMesh", 2, 2)
 
-# This creates a mesh hierarchy of length `L`.
-#
-# Now let's build a function space on the finest level of the mesh
-# hierarchy.
+# Now let's build a function space on the mesh.
 
-V = FunctionSpace(mesh_hierarchy[-1], 'DG', 0)
+V = FunctionSpace(mesh, 'DG', 0)
 
 # We are ready to build an ensemble of functions on that space, of size
 # `n`. Ensembles of functions can be written as lists or tuples for FADE.


### PR DESCRIPTION
Alterations:

- Added a function `fade_mesh` that can take in a `Mesh` type and arguments and return that `Mesh` but one that is part of a hierarchy with all the possible available meshes underneath it.
- Added tests for that functionality.
- No other tests need to be changed to `FadeMesh` and can stay as they are (explicitly stating a `MeshHierarchy` and picking finest `Mesh`).
- Examples for `ensemble_transform` sub-repo are changed and tutorials are changed also.