### PR TITLE
Accepting non-hierarchal mesh / speed-up of coarsening localisation

### DIFF
--- a/fade/emd/emd_kernel.py
+++ b/fade/emd/emd_kernel.py
@@ -248,9 +248,9 @@ def generate_localised_cost_tensor(ensemble_f, ensemble2_f, r_loc, option="kerne
             cost_tensor.dat.data[:] = x.dat.data[:]
         else:
             for i in range(n):
+                x = CoarseningLocalisation(cost_funcs[i][:], r_loc)
                 for j in range(n):
-                    x = CoarseningLocalisation(cost_funcs[i][j], r_loc)
-                    cost_tensor.dat.data[:, i, j] = x.dat.data[:]
+                    cost_tensor.dat.data[:, i, j] = x[j].dat.data[:]
 
     return cost_tensor
 

--- a/fade/ensemble_transform/weight_update.py
+++ b/fade/ensemble_transform/weight_update.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import
 
 from firedrake import *
 
-from firedrake.mg.utils import get_level
-
 import numpy as np
 
 from fade.observations import *
@@ -42,13 +40,6 @@ def weight_update(ensemble, weights, observation_operator, r_loc=0):
         raise ValueError('ensemble cannot be indexed')
     if len(weights) < 1:
         raise ValueError('weights cannot be indexed')
-    mesh = ensemble[0].function_space().mesh()
-
-    # check that part of a hierarchy - so that one can coarsen localise
-    hierarchy, lvl = get_level(mesh)
-    if lvl is None:
-        raise ValueError('mesh for ensemble members needs to be part of ' +
-                         'hierarchy for coarsening loc')
 
     # function space
     fs = ensemble[0].function_space()
@@ -69,9 +60,7 @@ def weight_update(ensemble, weights, observation_operator, r_loc=0):
 
     # now implement coarsening localisation and find weights
     with timed_stage("Coarsening localisation"):
-        W = []
-        for i in range(n):
-            W.append(CoarseningLocalisation(D[i], r_loc))
+        W = CoarseningLocalisation(D, r_loc)
 
     # Find Gaussian likelihood
     with timed_stage("Likelihood calculation"):

--- a/tests/test_localisation.py
+++ b/tests/test_localisation.py
@@ -85,13 +85,30 @@ def test_coarsening_localisation_no_hierarchy():
 
         WLoc_ = Function(fs).assign(WLoc)
 
-        if r == 1:
-            with pytest.raises(Exception):
-                CoarseningLocalisation(WLoc, r)
+        WLoc = CoarseningLocalisation(WLoc, r)
+        assert norm(assemble(WLoc - WLoc_)) == 0
 
-        if r == 0:
-            WLoc = CoarseningLocalisation(WLoc, r)
-            assert norm(assemble(WLoc - WLoc_)) == 0
+
+def test_coarsening_localisation_list():
+
+    mesh = UnitIntervalMesh(1)
+
+    mesh_hierarchy = MeshHierarchy(mesh, 1)
+
+    r_loc = 1
+
+    fs_hierarchy = tuple([FunctionSpace(m, 'DG', 0) for m in mesh_hierarchy])
+
+    WLoc = []
+    for i in range(2):
+        WLoc.append(Function(fs_hierarchy[1]))
+        WLoc[i].dat.data[0] = 1.0
+
+    WLoc = CoarseningLocalisation(WLoc, r_loc)
+
+    for i in range(2):
+        assert np.abs(0.5 - WLoc[i].dat.data[0]) < 1e-5
+        assert np.abs(0.5 - WLoc[i].dat.data[1]) < 1e-5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Alterations for speed-up of `CoarseningLocalisation`:

- Made `f`, the function argument of the method, able to be a `list` or `tuple` of functions, and this means that when localisation a whole ensemble of functions, one has to only preallocate one comparison function for the injection.

- Changed this in `weight_update` and `emd_kernel` where ensemble loops of `CoarseningLocalisation` are used.

- A test is added, showing that lists of functions can be an argument to `CoarseningLocalisation`.

Alterations for accepting non-hierarchal meshes:

- `CoarseningLocalisation` now doesn't throw an error when a non-hierarchy mesh is given, it just caps `r_loc` down to zero. This means that a check of hierarchy isn't needed in `weight_update` anymore; `CoarseningLocalisation` is simply carried out regardless, and the check to cap `r_loc` happens there.

- A test is edited to make sure when this happens the same function is returned (no localisation).