### PR TITLE
Optional R_loc args

### DIFF
--- a/fade/ensemble_transform/ensemble_transform.py
+++ b/fade/ensemble_transform/ensemble_transform.py
@@ -13,7 +13,7 @@ from fade.emd.emd_kernel import *
 from pyop2.profiling import timed_stage
 
 
-def ensemble_transform_update(ensemble, weights, r_loc):
+def ensemble_transform_update(ensemble, weights, r_loc=0):
 
     """ Computes the (localised) ensemble transform update in the etpf of a weighted ensemble
 
@@ -23,7 +23,9 @@ def ensemble_transform_update(ensemble, weights, r_loc):
         :arg weights: list of :class:`Function`s representing the importance weights
         :type weights: tuple / list
 
-        :arg r_loc: Radius of coarsening localisation for the cost functions
+        Optional Arguments:
+
+        :arg r_loc: Radius of coarsening localisation for the cost functions. Default: 0
         :type r_loc: int
 
     """

--- a/fade/ml/coupling.py
+++ b/fade/ml/coupling.py
@@ -16,7 +16,7 @@ import numpy as np
 from pyop2.profiling import timed_stage
 
 
-def seamless_coupling_update(ensemble_1, ensemble_2, weights_1, weights_2, r_loc_c, r_loc_f):
+def seamless_coupling_update(ensemble_1, ensemble_2, weights_1, weights_2, r_loc_c=0, r_loc_f=0):
 
     """ performs a seamless coupling (localised) ensemble transform update from a coupling
         between two weighted ensembles (coarse and fine) into two evenly weighted ensembles.
@@ -36,10 +36,12 @@ def seamless_coupling_update(ensemble_1, ensemble_2, weights_1, weights_2, r_loc
                         ensemble
         :type weights_2: tuple / list
 
-        :arg r_loc_c: Radius of coarsening localisation for the coarse cost functions
+        Optional Arguments:
+
+        :arg r_loc_c: Radius of coarsening localisation for the coarse cost functions. Default: 0
         :type r_loc_c: int
 
-        :arg r_loc_f: Radius of coarsening localisation for the fine cost functions
+        :arg r_loc_f: Radius of coarsening localisation for the fine cost functions. Default: 0
         :type r_loc_f: int
 
     """


### PR DESCRIPTION
As like in `weight_update`, the `r_loc` arguments in both `ensemble_transform` and `seamless_coupling` are both made optional, with default at 0.