### PR TITLE
changed path for emd_h to user/fade repo

### DIFF
--- a/fade/emd/emd_kernel.py
+++ b/fade/emd/emd_kernel.py
@@ -13,6 +13,8 @@ from firedrake import *
 from fade.localisation import *
 from fade.utils import *
 
+import fade
+
 import numpy as np
 
 import os
@@ -310,13 +312,13 @@ def kernel_transform(ensemble_f, ensemble2_f, weights, weights2, out_func, r_loc
         # update with cost tensor
         Dict.update({"cost_tensor":(cost_tensor, READ)})
 
-    # current working directory
-    p = os.getcwd()
+    # get fade/fade/emd directory
+    p = fade.emd.__path__[0]
 
     # key options for par_loop
-    ldargs=["-L" + p + "/fade/emd", "-Wl,-rpath," + p + "/fade/emd", "-lemd"]
+    ldargs=["-L" + p, "-Wl,-rpath," + p, "-lemd"]
     headers=["#include <emd.h>"]
-    include_dirs=[p + "/fade/emd"]
+    include_dirs=[p]
 
     # carry out par_loop -> out_func gets overwritten
     with timed_stage("Ensemble transform"):


### PR DESCRIPTION
Allows a user to use the `emd_kernel` code, and thus the full functionality of FADE in any repo, by using a path selector for the user's repo.